### PR TITLE
Toreless - draft-5 section 7.3: clarify whether or not Cloud Registrar needs WebPKI anchor

### DIFF
--- a/anima-brski-cloud.md
+++ b/anima-brski-cloud.md
@@ -536,11 +536,14 @@ In this way, a Pledge that may have been in a dusty box in a warehouse for a lon
 
 ## Trust Anchors for Cloud Registrar
 
-The Implicit TA database is used to authenticate the Cloud Registrar.
+The Implicit Trust Anchor database is used to authenticate the Cloud Registrar.
 This list is built-in by the manufacturer along with a DNS name to which to connect.
 (The manufacturer could even build in IP addresses as a last resort)
 
-The Cloud Registrar does not have a certificate that can be validated using a public (WebPKI) anchor.
+The Cloud Registrar may have a certificate that can be validated using a public (WebPKI) anchor.
+As another option, the Cloud Registrar may have a certificate that can be validated using a Private/Cloud PKI anchor as described in {{?I-D.irtf-t2trg-taxonomy-manufacturer-anchors}} section 3.
+The trust anchor, or trust anchors, to use is an implementation decision and out of scope of this document.
+
 The pledge may have any kind of Trust Anchor built in: from full multi-level WebPKI to the single self-signed certificate used by the Cloud Registrar.
 There are many tradeoffs to having more or less of the PKI present in the Pledge, which is addressed in part in {{?I-D.irtf-t2trg-taxonomy-manufacturer-anchors}} in sections 3 and 5.
 


### PR DESCRIPTION


close #86