### PR TITLE
remove Cloud/MASA connection, label redirects

### DIFF
--- a/anima-brski-cloud.md
+++ b/anima-brski-cloud.md
@@ -216,10 +216,10 @@ Both mechanisms are described in detail later in this document.
  On-site                Cloud
 +--------+                                          +-----------+
 | Pledge |------------------------------------------| Cloud     |
-+--------+                                          | Registrar |
-    |                                               +-+---------+
-    |                                                 | BRSKI-MASA
-    |                 +-----------+                 +-+---------+
++--------+          307 redirect                    | Registrar |
+    |                                               +-----------+
+    |
+    |                 +-----------+                 +-----------+
     +---------------->|  Owner    |-----------------|   MASA    |
         VR-sign(N)    | Registrar |sign(VR-sign(N)) +-----------+
                       +-----------+
@@ -235,7 +235,7 @@ Both mechanisms are described in detail later in this document.
  On-site                Cloud
 +--------+                                          +-----------+
 | Pledge |------------------------------------------| Cloud     |
-+--------+                                          | Registrar |
++--------+        referral via est-domain           | Registrar |
     |                                               +--+--------+
     |                                                  | BRSKI-MASA
     |                                               +--+--------+


### PR DESCRIPTION
While working on #236, I saw that there was an arc between the Cloud Registrar and the MASA, which I think does not need to be there.
(While the oem's Cloud` Registrar could well be co-located with it's MASA, the VAR's Registrar probably is standalone)
In Diagram two, there *is* a connection from Cloud Registrar to MASA (or a co-location), because a voucher is returned, which requires the MASA to sign it.
I've also labelled the Pledge<->Cloud Registrar arcs.
Is this better?